### PR TITLE
Do not remove nsqd connections in the case where all nsqlookupds are unreachable

### DIFF
--- a/lib/nsq.rb
+++ b/lib/nsq.rb
@@ -2,6 +2,8 @@ require_relative 'version'
 
 require_relative 'nsq/logger'
 
+require_relative 'nsq/exceptions'
+
 require_relative 'nsq/frames/frame'
 require_relative 'nsq/frames/error'
 require_relative 'nsq/frames/response'

--- a/lib/nsq/client_base.rb
+++ b/lib/nsq/client_base.rb
@@ -36,8 +36,14 @@ module Nsq
         @discovery = Discovery.new(opts[:nsqlookupds])
 
         loop do
-          nsqds = nsqds_from_lookupd(opts[:topic])
-          drop_and_add_connections(nsqds)
+          begin
+            nsqds = nsqds_from_lookupd(opts[:topic])
+            drop_and_add_connections(nsqds)
+          rescue DiscoveryException
+            # We can't connect to any nsqlookupds. That's okay, we'll just
+            # leave our current nsqd connections alone and try again later.
+            warn 'Could not connect to any nsqlookupd instances in discovery loop'
+          end
           sleep opts[:interval]
         end
 

--- a/lib/nsq/exceptions.rb
+++ b/lib/nsq/exceptions.rb
@@ -1,0 +1,5 @@
+module Nsq
+  # Raised when nsqlookupd discovery fails
+  class DiscoveryException < Exception; end
+end
+

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -2,7 +2,7 @@ module Nsq
   module Version
     MAJOR = 1
     MINOR = 2
-    PATCH = 0
+    PATCH = 1
     BUILD = nil
     STRING = [MAJOR, MINOR, PATCH, BUILD].compact.join('.')
   end

--- a/spec/lib/nsq/discovery_spec.rb
+++ b/spec/lib/nsq/discovery_spec.rb
@@ -90,4 +90,28 @@ describe Nsq::Discovery do
       end
     end
   end
+
+
+  describe 'when all lookupds are down' do
+    before do
+      @cluster.nsqlookupd.each(&:stop)
+      @discovery = new_discovery(@cluster.nsqlookupd)
+    end
+
+    describe '#nsqds' do
+      it 'throws an exception' do
+        expect {
+          @discovery.nsqds
+        }.to raise_error(Nsq::DiscoveryException)
+      end
+    end
+
+    describe '#nsqds_for_topic' do
+      it 'throws an exception' do
+        expect {
+          @discovery.nsqds_for_topic(@topic)
+        }.to raise_error(Nsq::DiscoveryException)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #9.