### PR TITLE
Added support to write to multiple topics from a single producer via Producer#write_to_topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ producer = Nsq::Producer.new(
 
 ### `#write`
 
-Publishes one or more message to nsqd. If you give it a single argument, it will
+Publishes one or more messages to nsqd. If you give it a single argument, it will
 send it to nsqd via `PUB`. If you give it multiple arguments, it will send all
 those messages to nsqd via `MPUB`. It will automatically call `to_s` on any
 arguments you give it.
@@ -106,6 +106,22 @@ and transmitted after reconnecting.
 connection to nsqd fails, you can lose messages. This is acceptable for our use
 cases, mostly because we are sending messages to a local nsqd instance and
 failure is very rare.
+
+
+### `#write_to_topic`
+
+Publishes one or more messages to nsqd. Like `#write`, but allows you to specify
+the topic. Use this method if you want a single producer instance to write to
+multiple topics.
+
+```Ruby
+# Send a single message via PUB to the topic 'rutabega'
+producer.write_to_topic('rutabega', 123)
+
+# Send multiple messages via MPUB to the topic 'kohlrabi'
+producer.write_to_topic('kohlrabi', 'a', 'b', 'c')
+```
+
 
 ### `#connected?`
 

--- a/lib/nsq/producer.rb
+++ b/lib/nsq/producer.rb
@@ -6,7 +6,7 @@ module Nsq
 
     def initialize(opts = {})
       @connections = {}
-      @topic = opts[:topic] || raise(ArgumentError, 'topic is required')
+      @topic = opts[:topic]
       @discovery_interval = opts[:discovery_interval] || 60
 
       nsqlookupds = []
@@ -30,6 +30,15 @@ module Nsq
 
 
     def write(*raw_messages)
+      if !@topic
+        raise 'No topic specified. Either specify a topic when instantiating the Producer or use write_to_topic.'
+      end
+
+      write_to_topic(@topic, *raw_messages)
+    end
+
+
+    def write_to_topic(topic, *raw_messages)
       # stringify the messages
       messages = raw_messages.map(&:to_s)
 
@@ -37,9 +46,9 @@ module Nsq
       connection = connection_for_write
 
       if messages.length > 1
-        connection.mpub(@topic, messages)
+        connection.mpub(topic, messages)
       else
-        connection.pub(@topic, messages.first)
+        connection.pub(topic, messages.first)
       end
     end
 

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,7 +1,7 @@
 module Nsq
   module Version
     MAJOR = 1
-    MINOR = 2
+    MINOR = 3
     PATCH = 1
     BUILD = nil
     STRING = [MAJOR, MINOR, PATCH, BUILD].compact.join('.')

--- a/spec/lib/nsq/producer_spec.rb
+++ b/spec/lib/nsq/producer_spec.rb
@@ -185,6 +185,12 @@ describe Nsq::Producer do
         consumer_a.terminate
         consumer_b.terminate
       end
+
+      it 'works if you pass it a symbol for topic' do
+        @producer.write_to_topic(:hello, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        wait_for{message_count('hello')==10}
+        expect(message_count('hello')).to eq(10)
+      end
     end
 
   end


### PR DESCRIPTION
@jf wanted to write to multiple topics from a single producer. It's a small change and makes sense to me. Decided to go with the most explicit option: adding a new method, `write_to_topic`. This makes it so we won't break `write` functionality.

@jf, will this do the trick?
@MaxPower15 @freerobby @ryanartecona Any thoughts?

Fixes #13