### PR TITLE
raise ArgumentError if msg not supplied to #write_to_topic

### DIFF
--- a/lib/nsq/producer.rb
+++ b/lib/nsq/producer.rb
@@ -39,6 +39,9 @@ module Nsq
 
 
     def write_to_topic(topic, *raw_messages)
+      # return error if message(s) not provided
+      raise ArgumentError, 'message not provided' if raw_messages.empty?
+
       # stringify the messages
       messages = raw_messages.map(&:to_s)
 

--- a/spec/lib/nsq/producer_spec.rb
+++ b/spec/lib/nsq/producer_spec.rb
@@ -135,6 +135,10 @@ describe Nsq::Producer do
     end
 
     describe '#write_to_topic' do
+      it 'returns an ArgumentError if no messages provided' do
+        expect { @producer.write_to_topic('topic-a') }.to raise_error(ArgumentError)
+      end
+
       it 'can queue a single message for a topic' do
         @producer.write_to_topic('topic-a', 'some-message')
         @producer.write_to_topic('topic-b', 'some-message')


### PR DESCRIPTION
If a message isn't supplied to `#write` or `#write_to_topic`, the following error is raised:

```
irb(main):001:0> require 'nsq'
=> true
irb(main):002:0> producer = Nsq::Producer.new( { nsqd: '127.0.0.1:4250' })
...
irb(main):003:0> producer.write_to_topic("events")
NoMethodError: undefined method `bytesize' for nil:NilClass
	from /Users/xxx/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/nsq-ruby-1.3.0/lib/nsq/connection.rb:94:in `pub'
	from /Users/xxx/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/nsq-ruby-1.3.0/lib/nsq/producer.rb:51:in `write_to_topic'
	from (irb):3
	from /Users/xxx/.rbenv/versions/2.1.2/bin/irb:11:in `<main>'
```

`#bytesize` obviously will fail if no message was provided. An explicit ArgumentError is probably  preferable to NoMethodError / nil:NilClass error from the downstream method.

Both ArgumentError and spec test have been added in this PR.