### PR TITLE
Add option to pop without blocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,16 +191,19 @@ Be aware, while `Consumer#pop` is blocking, your process will be unresponsive.
 This can be a problem in certain cases -- like if you're trying to gracefully
 restart a worker process by sending it a `TERM` signal.
 
+You can call `Consumer#pop(true)` to retrieve from the queue in non_block mode,
+which will throw a ThreadError instead of blocking if the queue is empty.
+
 If you're consuming from a low-volume topic and don't want to get stuck in a
 blocking state, use a pattern like this:
 
 ```Ruby
 loop do
-  if consumer.size > 0
-    msg = consumer.pop
+  begin
+    msg = @messages.pop(true) # non_block=true
     # do something
     msg.finish
-  else
+  rescue ThreadError # thrown by Queue#pop(non_block=true) when the queue is empty
     # wait for a bit before checking for new messages
     sleep 0.01
   end

--- a/lib/nsq/consumer.rb
+++ b/lib/nsq/consumer.rb
@@ -43,8 +43,14 @@ module Nsq
 
 
     # pop the next message off the queue
-    def pop
-      @messages.pop
+    def pop(non_block=false)
+      # By default, if the internal queue is empty, pop will block until
+      # a new message comes in.
+      #
+      # With non_block=true, if the internal queue is empty, it will raise a
+      # ThreadError instead of blocking.
+
+      @messages.pop(non_block)
     end
 
 

--- a/spec/lib/nsq/consumer_spec.rb
+++ b/spec/lib/nsq/consumer_spec.rb
@@ -68,6 +68,18 @@ describe Nsq::Consumer do
         @nsqd.pub(@consumer.topic, '☺')
         expect(@consumer.pop.body).to eq('☺')
       end
+
+      it 'blocks when there are no messages and non_block=false' do
+        assert_timeout do
+          @consumer.pop
+        end
+      end
+
+      it 'raises a ThreadError and does not block when there are no messages and non_block=true' do
+        assert_no_timeout(1) do
+          expect { @consumer.pop(true) }.to raise_error(ThreadError)
+        end
+      end
     end
 
 


### PR DESCRIPTION
Queue#pop's default behavior blocks when the queue is empty, until a new
message comes in.

It optionally takes a boolean non_block argument. When non_block=true, a
ThreadException is thrown when the queue is empty.

This PR adds the option of looping non-blocking Queue#pop requests until
the specified timeout expires, and returning nil if no message is found
in that time.