### PR TITLE
Simple TLSv1

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,7 @@ The Nsq::Producer constructor takes the following options:
 | `topic`       | Topic to which to publish messages     |                    |
 | `nsqd`        | Host and port of the nsqd instance     | '127.0.0.1:4150'   |
 | `nsqlookupd`  | Use lookupd to automatically discover nsqds |               |
-| `ssl_context` | Optional keys and certificates for TLS connections |        |
-| `tls_v1`      | Optional flag for simple tls v1 connections |               |
+| `ssl_context` or `ssl` | Optional keys and certificates for TLS connections or simple boolean | |
 
 For example, if you'd like to publish messages to a single nsqd.
 
@@ -94,6 +93,8 @@ producer = Nsq::Producer.new(
 ```
 
 If you need to connect using SSL/TLS Authentication via a `ssl_context`
+NOTE: `ssl_context` and `ssl` are interchangeable but `ssl_context` will win
+if both are present. There is no reason to have set.
 
 ```Ruby
 producer = Nsq::Producer.new(
@@ -112,7 +113,7 @@ If you need to connect using simple `tls_v1`
 producer = Nsq::Producer.new(
   nsqlookupd: ['1.2.3.4:4161', '6.7.8.9:4161'],
   topic: 'topic-of-great-esteem',
-  tls_v1: true
+  ssl: true
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The Nsq::Producer constructor takes the following options:
 | `nsqd`        | Host and port of the nsqd instance     | '127.0.0.1:4150'   |
 | `nsqlookupd`  | Use lookupd to automatically discover nsqds |               |
 | `ssl_context` | Optional keys and certificates for TLS connections |        |
+| `tls_v1`      | Optional flag for simple tls v1 connections |               |
 
 For example, if you'd like to publish messages to a single nsqd.
 
@@ -92,7 +93,7 @@ producer = Nsq::Producer.new(
 )
 ```
 
-If you need to connect using SSL/TLS
+If you need to connect using SSL/TLS Authentication via a `ssl_context`
 
 ```Ruby
 producer = Nsq::Producer.new(
@@ -105,6 +106,15 @@ producer = Nsq::Producer.new(
 )
 ```
 
+If you need to connect using simple `tls_v1`
+
+```Ruby
+producer = Nsq::Producer.new(
+  nsqlookupd: ['1.2.3.4:4161', '6.7.8.9:4161'],
+  topic: 'topic-of-great-esteem',
+  tls_v1: true
+)
+```
 
 ### `#write`
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The Nsq::Producer constructor takes the following options:
 | `topic`       | Topic to which to publish messages     |                    |
 | `nsqd`        | Host and port of the nsqd instance     | '127.0.0.1:4150'   |
 | `nsqlookupd`  | Use lookupd to automatically discover nsqds |               |
-| `ssl_context` or `ssl` | Optional keys and certificates for TLS connections or simple boolean | |
+| `ssl_context` **or** `ssl` | Optional keys and certificates for TLS connections **or** boolean | |
 
 For example, if you'd like to publish messages to a single nsqd.
 
@@ -93,8 +93,9 @@ producer = Nsq::Producer.new(
 ```
 
 If you need to connect using SSL/TLS Authentication via a `ssl_context`
-NOTE: `ssl_context` and `ssl` are interchangeable but `ssl_context` will win
-if both are present. There is no reason to have set.
+
+**NOTE**: `ssl_context` and `ssl` are interchangeable but `ssl_context` will win
+if both are present. There is no reason to have both set at the same time.
 
 ```Ruby
 producer = Nsq::Producer.new(

--- a/lib/nsq/client_base.rb
+++ b/lib/nsq/client_base.rb
@@ -90,7 +90,8 @@ module Nsq
       connection = Connection.new({
         host: host,
         port: port,
-        ssl_context: @ssl_context
+        ssl_context: @ssl_context,
+        tls_v1: @tls_v1
       }.merge(options))
       @connections[nsqd] = connection
     end

--- a/lib/nsq/client_base.rb
+++ b/lib/nsq/client_base.rb
@@ -91,7 +91,6 @@ module Nsq
         host: host,
         port: port,
         ssl_context: @ssl_context,
-        tls_v1: @tls_v1
       }.merge(options))
       @connections[nsqd] = connection
     end

--- a/lib/nsq/connection.rb
+++ b/lib/nsq/connection.rb
@@ -32,6 +32,7 @@ module Nsq
       @msg_timeout = opts[:msg_timeout] || 60_000 # 60s
       @max_in_flight = opts[:max_in_flight] || 1
       @ssl_context = opts[:ssl_context]
+      @tls_v1 = !!opts[:tls_v1]
       validate_ssl_context! if @ssl_context
 
       if @msg_timeout < 1000
@@ -152,7 +153,7 @@ module Nsq
         heartbeat_interval: 30_000, # 30 seconds
         output_buffer: 16_000, # 16kb
         output_buffer_timeout: 250, # 250ms
-        tls_v1: !!@ssl_context,
+        tls_v1: !!@ssl_context || @tls_v1,
         snappy: false,
         deflate: false,
         sample_rate: 0, # disable sampling
@@ -320,7 +321,7 @@ module Nsq
       # it gets to nsqd ahead of anything in the `@write_queue`
       write_to_socket '  V2'
       identify
-      upgrade_to_ssl_socket if @ssl_context
+      upgrade_to_ssl_socket if @ssl_context || @tls_v1
 
       start_read_loop
       start_write_loop

--- a/lib/nsq/connection.rb
+++ b/lib/nsq/connection.rb
@@ -355,12 +355,15 @@ module Nsq
 
 
     def upgrade_to_ssl_socket
-      @socket = OpenSSL::SSL::SSLSocket.new(@socket, openssl_context)
+      ssl_opts = [@socket, openssl_context].compact
+      @socket = OpenSSL::SSL::SSLSocket.new(*ssl_opts)
       @socket.connect
     end
 
 
     def openssl_context
+      return unless @ssl_context
+
       context = OpenSSL::SSL::SSLContext.new
       context.cert = OpenSSL::X509::Certificate.new(File.open(@ssl_context[:certificate]))
       context.key = OpenSSL::PKey::RSA.new(File.open(@ssl_context[:key]))

--- a/lib/nsq/connection.rb
+++ b/lib/nsq/connection.rb
@@ -32,8 +32,7 @@ module Nsq
       @msg_timeout = opts[:msg_timeout] || 60_000 # 60s
       @max_in_flight = opts[:max_in_flight] || 1
       @ssl_context = opts[:ssl_context]
-      @tls_v1 = !!opts[:tls_v1]
-      validate_ssl_context! if @ssl_context
+      validate_ssl_context! if @ssl_context.kind_of?(Hash)
 
       if @msg_timeout < 1000
         raise ArgumentError, 'msg_timeout cannot be less than 1000. it\'s in milliseconds.'
@@ -153,7 +152,7 @@ module Nsq
         heartbeat_interval: 30_000, # 30 seconds
         output_buffer: 16_000, # 16kb
         output_buffer_timeout: 250, # 250ms
-        tls_v1: !!@ssl_context || @tls_v1,
+        tls_v1: !!@ssl_context,
         snappy: false,
         deflate: false,
         sample_rate: 0, # disable sampling
@@ -321,7 +320,7 @@ module Nsq
       # it gets to nsqd ahead of anything in the `@write_queue`
       write_to_socket '  V2'
       identify
-      upgrade_to_ssl_socket if @ssl_context || @tls_v1
+      upgrade_to_ssl_socket if @ssl_context
 
       start_read_loop
       start_write_loop
@@ -362,7 +361,7 @@ module Nsq
 
 
     def openssl_context
-      return unless @ssl_context
+      return unless @ssl_context.kind_of?(Hash)
 
       context = OpenSSL::SSL::SSLContext.new
       context.cert = OpenSSL::X509::Certificate.new(File.open(@ssl_context[:certificate]))

--- a/lib/nsq/consumer.rb
+++ b/lib/nsq/consumer.rb
@@ -18,6 +18,7 @@ module Nsq
       @discovery_interval = opts[:discovery_interval] || 60
       @msg_timeout = opts[:msg_timeout]
       @ssl_context = opts[:ssl_context]
+      @tls_v1 = opts[:tls_v1]
 
       # This is where we queue up the messages we receive from each connection
       @messages = opts[:queue] || Queue.new

--- a/lib/nsq/consumer.rb
+++ b/lib/nsq/consumer.rb
@@ -17,8 +17,7 @@ module Nsq
       @max_in_flight = opts[:max_in_flight] || 1
       @discovery_interval = opts[:discovery_interval] || 60
       @msg_timeout = opts[:msg_timeout]
-      @ssl_context = opts[:ssl_context]
-      @tls_v1 = opts[:tls_v1]
+      @ssl_context = opts[:ssl_context] || opts[:ssl]
 
       # This is where we queue up the messages we receive from each connection
       @messages = opts[:queue] || Queue.new

--- a/lib/nsq/producer.rb
+++ b/lib/nsq/producer.rb
@@ -9,6 +9,7 @@ module Nsq
       @topic = opts[:topic]
       @discovery_interval = opts[:discovery_interval] || 60
       @ssl_context = opts[:ssl_context]
+      @tls_v1 = opts[:tls_v1]
 
       nsqlookupds = []
       if opts[:nsqlookupd]

--- a/lib/nsq/producer.rb
+++ b/lib/nsq/producer.rb
@@ -8,8 +8,7 @@ module Nsq
       @connections = {}
       @topic = opts[:topic]
       @discovery_interval = opts[:discovery_interval] || 60
-      @ssl_context = opts[:ssl_context]
-      @tls_v1 = opts[:tls_v1]
+      @ssl_context = opts[:ssl_context] || opts[:ssl]
 
       nsqlookupds = []
       if opts[:nsqlookupd]

--- a/spec/lib/nsq/tls_connection_spec.rb
+++ b/spec/lib/nsq/tls_connection_spec.rb
@@ -53,13 +53,13 @@ describe Nsq::Connection do
 
   describe 'when using a simple tls connection' do
     it 'can write a message onto the queue and read it back off again' do
-      producer = new_producer(@nsqd, tls_v1: true)
+      producer = new_producer(@nsqd, ssl: true)
       topic = producer.topic
       producer.write('some-tls-message')
       wait_for { message_count(topic) == 1 }
       expect(message_count(topic)).to eq(1)
 
-      consumer = new_consumer(tls_v1: true)
+      consumer = new_consumer(ssl: true)
       msg = consumer.pop
       expect(msg.body).to eq('some-tls-message')
       msg.finish

--- a/spec/lib/nsq/tls_connection_spec.rb
+++ b/spec/lib/nsq/tls_connection_spec.rb
@@ -30,7 +30,7 @@ describe Nsq::Connection do
     @cluster.destroy
   end
 
-  describe 'when using a tls connection' do
+  describe 'when using a full tls context' do
     it 'can write a message onto the queue and read it back off again' do
       producer = new_producer(@nsqd, ssl_context: ssl_context)
       topic = producer.topic
@@ -39,6 +39,27 @@ describe Nsq::Connection do
       expect(message_count(topic)).to eq(1)
 
       consumer = new_consumer(ssl_context: ssl_context)
+      msg = consumer.pop
+      expect(msg.body).to eq('some-tls-message')
+      msg.finish
+
+      expect(msg.connection.instance_variable_get(:@socket)).
+        to be_instance_of(OpenSSL::SSL::SSLSocket)
+
+      producer.terminate
+      consumer.terminate
+    end
+  end
+
+  describe 'when using a simple tls connection' do
+    it 'can write a message onto the queue and read it back off again' do
+      producer = new_producer(@nsqd, tls_v1: true)
+      topic = producer.topic
+      producer.write('some-tls-message')
+      wait_for { message_count(topic) == 1 }
+      expect(message_count(topic)).to eq(1)
+
+      consumer = new_consumer(tls_v1: true)
       msg = consumer.pop
       expect(msg.body).to eq('some-tls-message')
       msg.finish


### PR DESCRIPTION
This implements a TLSv1 flag for servers that are not looking to do full cert/key authentication.

Changes
---------
* Add an additional optional option (`tls_v1`) that can toggle the use of an `SSLSocket` without the need for a full `ssl_context`
* Ensure TLS works with this new flag alone, with this flag and a passed `ssl_context`, or with just a `ssl_context`
* Small test using this flag through consumption and production

Fixes https://github.com/wistia/nsq-ruby/issues/24