### PR TITLE
Add test for ephemeral topic discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.1
+
+* Bugfix: Allow discovery of ephemeral topics when using JRuby.
+
 ## 2.0.0
 
 * Enable TLS connections without any client-side keys, certificates or certificate authorities.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
+## 2.0.1
+
+* Bugfix: URI escape topic for discovery to handle #ephemeral topics
+
 ## 2.0.0
 
 * Enable TLS connections without any client-side keys, certificates or certificate authorities.
-* Deprecate ssl_context connection setting, rename it to tls_options moving forward.
+* Deprecate `ssl_context` connection setting, rename it to `tls_options` moving forward.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## 2.0.1
-
-* Bugfix: URI escape topic for discovery to handle #ephemeral topics
-
 ## 2.0.0
 
 * Enable TLS connections without any client-side keys, certificates or certificate authorities.

--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ millions of messages a day.
 - Anders Chen ([@chen-anders](https://github.com/chen-anders))
 - Thomas O'Neil ([@alieander](https://github.com/alieander))
 - Unbekandt Léo ([@soulou](https://github.com/Soulou))
+- Matthias Schneider ([@mschneider82](https://github.com/mschneider82))
 
 
 ## MIT License

--- a/lib/nsq/discovery.rb
+++ b/lib/nsq/discovery.rb
@@ -70,7 +70,7 @@ module Nsq
       uri.query = "ts=#{Time.now.to_i}"
       if topic
         uri.path = '/lookup'
-        uri.query += "&topic=#{topic}"
+        uri.query += "&topic=#{URI.escape(topic)}"
       else
         uri.path = '/nodes'
       end

--- a/lib/nsq/discovery.rb
+++ b/lib/nsq/discovery.rb
@@ -70,7 +70,7 @@ module Nsq
       uri.query = "ts=#{Time.now.to_i}"
       if topic
         uri.path = '/lookup'
-        uri.query += "&topic=#{URI.escape(topic)}"
+        uri.query += "&topic=#{topic}"
       else
         uri.path = '/nodes'
       end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -2,7 +2,7 @@ module Nsq
   module Version
     MAJOR = 2
     MINOR = 0
-    PATCH = 1
+    PATCH = 0
     BUILD = nil
     STRING = [MAJOR, MINOR, PATCH, BUILD].compact.join('.')
   end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -2,7 +2,7 @@ module Nsq
   module Version
     MAJOR = 2
     MINOR = 0
-    PATCH = 0
+    PATCH = 1
     BUILD = nil
     STRING = [MAJOR, MINOR, PATCH, BUILD].compact.join('.')
   end

--- a/spec/lib/nsq/discovery_spec.rb
+++ b/spec/lib/nsq/discovery_spec.rb
@@ -57,6 +57,16 @@ describe Nsq::Discovery do
         nsqds = @discovery.nsqds_for_topic(@topic)
         expect(nsqds.sort).to eq(@expected_topic_lookup_nsqds)
       end
+
+      it 'returns nsqds for an ephemeral topic' do
+        ephemeral_topic = 'the-topic-of-note#ephemeral'
+        nsqd_with_ephemeral_topic = @cluster.nsqd.sample
+        nsqd_with_ephemeral_topic.pub(ephemeral_topic, 'some-message')
+
+        nsqds = @discovery.nsqds_for_topic(ephemeral_topic)
+        expected_nsqds = [nsqd_with_ephemeral_topic].map{|d|"#{d.host}:#{d.tcp_port}"}.sort
+        expect(nsqds.sort).to eq(expected_nsqds)
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #27. Well, not exactly.

I went to write a failing test for ephemeral topic discovery but couldn't do it. It worked!
The reason for this is that when we add unescaped characters to `uri.query` it will ultimately escape them when making the HTTP call:

```ruby
uri1 = URI.parse 'https://1.2.3.4/blah'
uri1.query = 'this=that#thing'
uri2 = URI.parse 'https://1.2.3.4/blah'
uri2.query = 'this=that%23thing'
uri1 == uri2 #=> true
```

@mschneider82, maybe there was another reason it wasn't working for you? I'm all confused now :)