### PR TITLE
File.read over File.open for SSLContext

### DIFF
--- a/lib/nsq/connection.rb
+++ b/lib/nsq/connection.rb
@@ -380,10 +380,10 @@ module Nsq
       return unless @tls_options
 
       context = OpenSSL::SSL::SSLContext.new
-      context.cert = OpenSSL::X509::Certificate.new(File.open(@tls_options[:certificate]))
-      context.key = OpenSSL::PKey::RSA.new(File.open(@tls_options[:key]))
+      context.cert = OpenSSL::X509::Certificate.new(File.read(@tls_options[:certificate]))
+      context.key = OpenSSL::PKey::RSA.new(File.read(@tls_options[:key]))
       if @tls_options[:ca_certificate]
-        context.ca_file = OpenSSL::X509::Certificate.new(File.open(@tls_options[:ca_certificate])).to_pem
+        context.ca_file = OpenSSL::X509::Certificate.new(File.read(@tls_options[:ca_certificate])).to_pem
       end
       context
     end


### PR DESCRIPTION
All of these Context certs expect a string.
`File.open` responds to `.to_s` so this has worked fine until now... However it was then never cleaning up the open `File` until garbage collection. This change will `read` the file right into a string and close the file straight away being a bit more resource friendly over time.