### PR TITLE
Fix ca_certificate; add :verify_mode to tls_options

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ producer = Nsq::Producer.new(
   tls_v1: true,
   tls_options: {
     key: '/path/to/ssl/key.pem',
-    certificate: '/path/to/ssl/certificate.pem'
+    certificate: '/path/to/ssl/certificate.pem',
+    ca_certificate: '/path/to/ssl/ca_certificate.pem',
+    verify_mode: OpenSSL::SSL::VERIFY_PEER
   }
 )
 ```
@@ -200,7 +202,9 @@ consumer = Nsq::Consumer.new(
   tls_v1: true,
   tls_options: {
     key: '/path/to/ssl/key.pem',
-    certificate: '/path/to/ssl/certificate.pem'
+    certificate: '/path/to/ssl/certificate.pem',
+    ca_certificate: '/path/to/ssl/ca_certificate.pem',
+    verify_mode: OpenSSL::SSL::VERIFY_PEER
   }
 )
 ```

--- a/lib/nsq/connection.rb
+++ b/lib/nsq/connection.rb
@@ -383,7 +383,7 @@ module Nsq
       context.cert = OpenSSL::X509::Certificate.new(File.read(@tls_options[:certificate]))
       context.key = OpenSSL::PKey::RSA.new(File.read(@tls_options[:key]))
       if @tls_options[:ca_certificate]
-        context.ca_file = OpenSSL::X509::Certificate.new(File.read(@tls_options[:ca_certificate])).to_pem
+        context.ca_file = @tls_options[:ca_certificate]
       end
       context
     end

--- a/lib/nsq/connection.rb
+++ b/lib/nsq/connection.rb
@@ -385,6 +385,7 @@ module Nsq
       if @tls_options[:ca_certificate]
         context.ca_file = @tls_options[:ca_certificate]
       end
+      context.verify_mode = @tls_options[:verify_mode] || OpenSSL::SSL::VERIFY_NONE
       context
     end
 

--- a/spec/lib/nsq/tls_connection_spec.rb
+++ b/spec/lib/nsq/tls_connection_spec.rb
@@ -58,6 +58,22 @@ describe Nsq::Connection do
     end
   end
 
+  describe 'when verify_mode is passed' do
+    it 'fails if certificates do not verify' do
+      tls_options = tls_options_fixture.merge(verify_mode: OpenSSL::SSL::VERIFY_PEER)
+      tls_options.delete(:ca_certificate)
+
+      params = {
+        tls_v1: true,
+        tls_options: tls_options
+      }
+
+      expect {
+        new_producer(@nsqd, params)
+      }.to raise_error(OpenSSL::SSL::SSLError, /certificate verify failed/)
+    end
+  end
+
   describe 'when using a simple tls connection' do
     it 'can write a message onto the queue and read it back off again' do
       producer = new_producer(@nsqd, tls_v1: true)


### PR DESCRIPTION
Why?
-----
Currently if you attempt to use the `ca_certificate` you will get errors when it attempts to use the given pem to located a file with that path/descriptor on disk. :( This was simply an bug...
Additionally, using certificates is far more useful if you can easily verify that you are not talking to the wrong server.

Change
--------
This allow a simple passthrough of the various `OpenSSL::SSL` verify modes which is needed because the default behaviour is to use `OpenSSL::SSL::VERIFY_NONE`...
This implementation additionally makes it a little more apparent that this is the default by also defaulting to it here.