### PR TITLE
Close the TcpSocket when closing the connection

### DIFF
--- a/lib/nsq/connection.rb
+++ b/lib/nsq/connection.rb
@@ -357,6 +357,7 @@ module Nsq
       cls if connected?
       stop_read_loop
       stop_write_loop
+      @socket.close
       @socket = nil
       @connected = false
     end


### PR DESCRIPTION
As mentioned in #34, when `close_connection` is called, the Socket isn't actually close, just set to `nil`. This can leave open sockets hanging around which can end up causing issues.