### PR TITLE
Close sockets when closing the connection

### DIFF
--- a/lib/nsq/connection.rb
+++ b/lib/nsq/connection.rb
@@ -357,7 +357,7 @@ module Nsq
       cls if connected?
       stop_read_loop
       stop_write_loop
-      @socket.close
+      @socket.close if @socket
       @socket = nil
       @connected = false
     end

--- a/lib/nsq/connection.rb
+++ b/lib/nsq/connection.rb
@@ -374,6 +374,7 @@ module Nsq
     def upgrade_to_ssl_socket
       ssl_opts = [@socket, openssl_context].compact
       @socket = OpenSSL::SSL::SSLSocket.new(*ssl_opts)
+      @socket.sync_close = true
       @socket.connect
     end
 

--- a/lib/nsq/connection.rb
+++ b/lib/nsq/connection.rb
@@ -357,6 +357,7 @@ module Nsq
       cls if connected?
       stop_read_loop
       stop_write_loop
+      @socket.close
       @socket = nil
       @connected = false
     end


### PR DESCRIPTION
Without calling `@socket.close`, the sockets will be left open when `close_connection` is called.

This PR fixes an issue described in #34 

Changes:

* call `@socket.close` when closing the connection just before setting it to nil
* set `sync_close` to true when upgrading to an SSL connection so that the underlying TCP connection is closed at the same time.