### PR TITLE
Make Nsq::Discovery compatible with v1.0.0-compat responses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,15 @@ cache: bundler
 rvm:
   - 2.3.3
 
+env:
+  matrix:
+    - "NSQ=nsq-1.0.0-compat.linux-amd64.go1.8"
+    - "NSQ=nsq-0.3.8.linux-amd64.go1.6.2"
+
 before_install:
-  - wget https://s3.amazonaws.com/bitly-downloads/nsq/nsq-0.3.8.linux-amd64.go1.6.2.tar.gz -O /tmp/nsq.tar.gz
+  - wget https://s3.amazonaws.com/bitly-downloads/nsq/$NSQ.tar.gz -O /tmp/nsq.tar.gz
   - tar -xvf /tmp/nsq.tar.gz
-  - export PATH=$PATH:$PWD/nsq-0.3.8.linux-amd64.go1.6.2/bin/
+  - export PATH=$PATH:$PWD/$NSQ/bin/
 
 script:
   - bundle exec rake spec

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source 'http://rubygems.org'
 group :development do
   gem 'bundler', '~> 1.0'
   gem 'jeweler', '~> 2.0'
-  gem 'nsq-cluster', '~> 1.1'
+  gem 'nsq-cluster', '~> 2.1'
   gem 'rspec', '~> 3.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ GEM
     multipart-post (2.0.0)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
-    nsq-cluster (1.1.1)
+    nsq-cluster (2.1.0)
       sys-proctable
     oauth2 (1.3.1)
       faraday (>= 0.8, < 0.12)
@@ -74,7 +74,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.0)
   jeweler (~> 2.0)
-  nsq-cluster (~> 1.1)
+  nsq-cluster (~> 2.1)
   rspec (~> 3.0)
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,10 +3,10 @@ GEM
   specs:
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
-    builder (3.2.2)
+    builder (3.2.3)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    diff-lcs (1.2.5)
+    diff-lcs (1.3)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     git (1.3.0)
@@ -18,9 +18,9 @@ GEM
       multi_json (>= 1.7.5, < 2.0)
       nokogiri (~> 1.6.0)
       oauth2
-    hashie (3.4.6)
+    hashie (3.5.5)
     highline (1.7.8)
-    jeweler (2.2.1)
+    jeweler (2.3.3)
       builder
       bundler (>= 1.0)
       git (>= 1.2.5)
@@ -30,42 +30,43 @@ GEM
       psych (~> 2.2)
       rake
       rdoc
-      semver
+      semver2
     jwt (1.5.6)
     mini_portile2 (2.1.0)
     multi_json (1.12.1)
-    multi_xml (0.5.5)
+    multi_xml (0.6.0)
     multipart-post (2.0.0)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
-    nsq-cluster (1.1.0)
+    nsq-cluster (1.1.1)
       sys-proctable
-    oauth2 (1.2.0)
-      faraday (>= 0.8, < 0.10)
+    oauth2 (1.3.1)
+      faraday (>= 0.8, < 0.12)
       jwt (~> 1.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    psych (2.2.0)
-    public_suffix (2.0.4)
+    psych (2.2.4)
+    public_suffix (2.0.5)
     rack (2.0.1)
-    rake (11.3.0)
-    rdoc (5.0.0)
-    rspec (3.0.0)
-      rspec-core (~> 3.0.0)
-      rspec-expectations (~> 3.0.0)
-      rspec-mocks (~> 3.0.0)
-    rspec-core (3.0.3)
-      rspec-support (~> 3.0.0)
-    rspec-expectations (3.0.3)
+    rake (12.0.0)
+    rdoc (5.1.0)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.0.0)
-    rspec-mocks (3.0.3)
-      rspec-support (~> 3.0.0)
-    rspec-support (3.0.3)
-    semver (1.0.1)
-    sys-proctable (0.9.4)
-    thread_safe (0.3.5)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    semver2 (3.4.2)
+    sys-proctable (1.1.3-universal-aix5)
+    thread_safe (0.3.6)
 
 PLATFORMS
   ruby
@@ -77,4 +78,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.13.7
+   1.14.6

--- a/lib/nsq/discovery.rb
+++ b/lib/nsq/discovery.rb
@@ -78,9 +78,11 @@ module Nsq
       begin
         body = Net::HTTP.get(uri)
         data = JSON.parse(body)
+        producers = data['producers'] || # v1.0.0-compat
+                      (data['data'] && data['data']['producers'])
 
-        if data['data'] && data['data']['producers']
-          data['data']['producers'].map do |producer|
+        if producers
+          producers.map do |producer|
             "#{producer['broadcast_address']}:#{producer['tcp_port']}"
           end
         else

--- a/spec/lib/nsq/connection_spec.rb
+++ b/spec/lib/nsq/connection_spec.rb
@@ -18,21 +18,21 @@ describe Nsq::Connection do
 
       expect{
         Nsq::Connection.new(host: @nsqd.host, port: @nsqd.tcp_port)
-      }.to raise_error
+      }.to raise_error(Errno::ECONNREFUSED)
     end
 
     it 'should raise an exception if it connects to something that isn\'t nsqd' do
       expect{
         # try to connect to the HTTP port instead of TCP
         Nsq::Connection.new(host: @nsqd.host, port: @nsqd.http_port)
-      }.to raise_error
+      }.to raise_error(RuntimeError, /Bad frame type specified/)
     end
 
     it 'should raise an exception if max_in_flight is above what the server supports' do
       expect{
         # try to connect to the HTTP port instead of TCP
         Nsq::Connection.new(host: @nsqd.host, port: @nsqd.tcp_port, max_in_flight: 1_000_000)
-      }.to raise_error
+      }.to raise_error(RuntimeError, "max_in_flight is set to 1000000, server only supports 2500")
     end
 
     %w(tls_options ssl_context).map(&:to_sym).each do |tls_options_key|

--- a/spec/lib/nsq/consumer_spec.rb
+++ b/spec/lib/nsq/consumer_spec.rb
@@ -28,7 +28,7 @@ describe Nsq::Consumer do
 
         expect{
           new_consumer(nsqlookupd: nil, nsqd: "#{@nsqd.host}:#{@nsqd.tcp_port}")
-        }.to raise_error
+        }.to raise_error(Errno::ECONNREFUSED)
       end
     end
 

--- a/spec/lib/nsq/producer_spec.rb
+++ b/spec/lib/nsq/producer_spec.rb
@@ -3,7 +3,8 @@ require 'json'
 
 describe Nsq::Producer do
   def message_count(topic = @producer.topic)
-    topics_info = JSON.parse(@nsqd.stats.body)['data']['topics']
+    parsed_body = JSON.parse(@nsqd.stats.body)
+    topics_info = (parsed_body['data'] || parsed_body)['topics']
     topic_info = topics_info.select{|t| t['topic_name'] == topic }.first
     if topic_info
       topic_info['message_count']

--- a/spec/lib/nsq/producer_spec.rb
+++ b/spec/lib/nsq/producer_spec.rb
@@ -40,7 +40,7 @@ describe Nsq::Producer do
 
         expect{
           new_producer(@nsqd)
-        }.to raise_error
+        }.to raise_error(Errno::ECONNREFUSED)
       end
     end
 
@@ -83,7 +83,9 @@ describe Nsq::Producer do
       end
 
       it 'raises an exception if delay is negative' do
-        expect {@producer.deferred_write -10, 1}.to raise_error
+        expect {
+          @producer.deferred_write -10, 1
+        }.to raise_error(RuntimeError, "Delay can't be negative, use a positive float.")
       end
 
       it 'shouldn\'t raise an error when nsqd is down' do
@@ -273,7 +275,7 @@ describe Nsq::Producer do
         wait_for{ @producer.connections.length == 0 }
         expect {
           @producer.write('die')
-        }.to raise_error
+        }.to raise_error(RuntimeError, /No connections available/)
       end
     end
 

--- a/spec/lib/nsq/tls_connection_spec.rb
+++ b/spec/lib/nsq/tls_connection_spec.rb
@@ -2,7 +2,8 @@ require_relative '../../spec_helper'
 
 describe Nsq::Connection do
   def message_count(topic)
-    topics_info = JSON.parse(@nsqd.stats.body)['data']['topics']
+    parsed_body = JSON.parse(@nsqd.stats.body)
+    topics_info = (parsed_body['data'] || parsed_body)['topics']
     topic_info = topics_info.select{|t| t['topic_name'] == topic }.first
     if topic_info
       topic_info['message_count']


### PR DESCRIPTION
This PR implements a solution for https://github.com/wistia/nsq-ruby/issues/37

Notes:

- I had a spec failure locally, I'll try to fix it as soon as possible

```sh
.................F...............................................................

Failures:

  1) Nsq::Producer connecting via nsqlookupd #connections should be connected to all nsqds
     Failure/Error: wait_for{ @producer.connections.length == @cluster.nsqd.length }
     Timeout::Error:
       execution expired
     # ./spec/spec_helper.rb:47:in `sleep'
     # ./spec/spec_helper.rb:47:in `block (2 levels) in wait_for'
     # ./spec/spec_helper.rb:45:in `loop'
     # ./spec/spec_helper.rb:45:in `block in wait_for'
     # ./spec/spec_helper.rb:44:in `wait_for'
     # ./spec/lib/nsq/producer_spec.rb:230:in `block (3 levels) in <top (required)>'

Finished in 24.4 seconds (files took 0.222 seconds to load)
81 examples, 1 failure

Failed examples:

rspec ./spec/lib/nsq/producer_spec.rb:240 # Nsq::Producer connecting via nsqlookupd #connections should be connected to all nsqds
```

- Do you have any plan of testing this on any CI service? I'll setup travis.yml on a specific branch so we can test different NSQ version at the same time, we just need to use specific docker images tag. Does it make sense for you?