### PR TITLE
add Timeout block wait for the first avalible nsqd when use nsqlokupd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ pkg
 
 # for Mac
 .DS_Store
+
+# for rubymine
+.idea/

--- a/lib/nsq/producer.rb
+++ b/lib/nsq/producer.rb
@@ -15,16 +15,19 @@ module Nsq
 
       nsqlookupds = []
       if opts[:nsqlookupd]
+        nsqlookupd_blocking = opts[:nsqlookupd_blocking] || false
+        nsqlookupd_timeout = opts[:nsqlookupd_timeout] || 5
+
         nsqlookupds = [opts[:nsqlookupd]].flatten
         discover_repeatedly(
           nsqlookupds: nsqlookupds,
           interval: @discovery_interval
         )
 
-        # no_wait_first_nsqd: do not wait for the first avalible nsqd
-        return if opts[:no_wait_first_nsqd]
+        # nsqlookupd_blocking: don't wait for the first avalible nsqd
+        return unless nsqlookupd_blocking
         #  first time init producer wait for nsqlookupd connect to get first avalible nsqd
-        Timeout.timeout(opts[:nsqlookup_timeout] || 5) do
+        Timeout.timeout(nsqlookupd_timeout) do
           while @connections.values.select(&:connected?).size == 0
             sleep(0.1)
           end

--- a/spec/lib/nsq/producer_spec.rb
+++ b/spec/lib/nsq/producer_spec.rb
@@ -5,7 +5,7 @@ describe Nsq::Producer do
   def message_count(topic = @producer.topic)
     parsed_body = JSON.parse(@nsqd.stats.body)
     topics_info = (parsed_body['data'] || parsed_body)['topics']
-    topic_info = topics_info.select{|t| t['topic_name'] == topic }.first
+    topic_info = topics_info.select { |t| t['topic_name'] == topic }.first
     if topic_info
       topic_info['message_count']
     else
@@ -39,7 +39,7 @@ describe Nsq::Producer do
       it 'should throw an exception when trying to connect to a server that\'s down' do
         @nsqd.stop
 
-        expect{
+        expect {
           new_producer(@nsqd)
         }.to raise_error(Errno::ECONNREFUSED)
       end
@@ -52,7 +52,7 @@ describe Nsq::Producer do
 
       it 'should return false when nsqd is down' do
         @nsqd.stop
-        wait_for{!@producer.connected?}
+        wait_for { !@producer.connected? }
         expect(@producer.connected?).to eq(false)
       end
     end
@@ -61,25 +61,25 @@ describe Nsq::Producer do
 
       it 'can queue a message' do
         @producer.write('some-message')
-        wait_for{message_count==1}
+        wait_for { message_count==1 }
         expect(message_count).to eq(1)
       end
 
       it 'can queue multiple messages at once' do
         @producer.write(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
-        wait_for{message_count==10}
+        wait_for { message_count==10 }
         expect(message_count).to eq(10)
       end
 
       it 'can queue a deferred message' do
         @producer.deferred_write 1.0, 1
-        wait_for{message_count==1}
+        wait_for { message_count==1 }
         expect(message_count).to eq(1)
       end
 
       it 'can queue multiple deferred messages' do
         @producer.deferred_write 1.0, 1, 2, 3
-        wait_for{message_count==3}
+        wait_for { message_count==3 }
         expect(message_count).to eq(3)
       end
 
@@ -92,8 +92,8 @@ describe Nsq::Producer do
       it 'shouldn\'t raise an error when nsqd is down' do
         @nsqd.stop
 
-        expect{
-          10.times{@producer.write('fail')}
+        expect {
+          10.times { @producer.write('fail') }
         }.to_not raise_error
       end
 
@@ -101,7 +101,7 @@ describe Nsq::Producer do
         @nsqd.stop
 
         # Write 10 messages while nsqd is down
-        10.times{|i| @producer.write(i)}
+        10.times { |i| @producer.write(i) }
 
         @nsqd.start
 
@@ -166,8 +166,8 @@ describe Nsq::Producer do
       it 'can queue a single message for a topic' do
         @producer.write_to_topic('topic-a', 'some-message')
         @producer.write_to_topic('topic-b', 'some-message')
-        wait_for{message_count('topic-a')==1}
-        wait_for{message_count('topic-b')==1}
+        wait_for { message_count('topic-a')==1 }
+        wait_for { message_count('topic-b')==1 }
         expect(message_count('topic-a')).to eq(1)
         expect(message_count('topic-b')).to eq(1)
       end
@@ -175,8 +175,8 @@ describe Nsq::Producer do
       it 'can queue multiple messages at once for a topic' do
         @producer.write_to_topic('topic-a', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
         @producer.write_to_topic('topic-b', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
-        wait_for{message_count('topic-a')==10}
-        wait_for{message_count('topic-b')==10}
+        wait_for { message_count('topic-a')==10 }
+        wait_for { message_count('topic-b')==10 }
         expect(message_count('topic-a')).to eq(10)
         expect(message_count('topic-b')).to eq(10)
       end
@@ -189,8 +189,8 @@ describe Nsq::Producer do
         @producer.write_to_topic('topic-b', 3, 4)
         @producer.write_to_topic('topic-a', 5)
 
-        wait_for{message_count('topic-a') == 3}
-        wait_for{message_count('topic-b') == 2}
+        wait_for { message_count('topic-a') == 3 }
+        wait_for { message_count('topic-b') == 2 }
 
         a_msgs = [1, 2, 5].map(&:to_s)
         b_msgs = [3, 4].map(&:to_s)
@@ -216,7 +216,7 @@ describe Nsq::Producer do
 
       it 'works if you pass it a symbol for topic' do
         @producer.write_to_topic(:hello, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
-        wait_for{message_count('hello')==10}
+        wait_for { message_count('hello')==10 }
         expect(message_count('hello')).to eq(10)
       end
     end
@@ -234,14 +234,14 @@ describe Nsq::Producer do
       @cluster.destroy
     end
 
-    it 'no_wait_first_nsqd should work' do
-      @producer = new_lookupd_producer(no_wait_first_nsqd: true)
+    it 'default non blocking' do
+      @producer = new_lookupd_producer
       expect(@producer.connections.length).to_not eq(@cluster.nsqd.length)
     end
 
     context 'wait for one avalible nsqd ready' do
       before do
-        @producer = new_lookupd_producer
+        @producer = new_lookupd_producer(nsqlookupd_blocking: true)
       end
 
       describe '#connected?' do
@@ -275,7 +275,7 @@ describe Nsq::Producer do
 
     context 'wait for all nsqd ready' do
       before do
-        @producer = new_lookupd_producer(no_wait_first_nsqd: true)
+        @producer = new_lookupd_producer
         # wait for it to connect to all nsqds
         wait_for { @producer.connections.length == @cluster.nsqd.length }
       end


### PR DESCRIPTION
This should ensure that a connection has been found prior to a write
attempt. 

```ruby
  p = Nsq::Producer.new(nsqlookupd: '127.0.0.1:4161', topic: 'st')
  # After Nsq::Producer.new atleast have one avalible nsqd can write message.
  q = p.write("hello world!")
  p.terminate
```

relate [fastly/nsq-ruby](https://github.com/fastly/nsq-ruby/commit/a8f308d3cafe317a2673b21ec78298a6bfcf90ce)