### PR TITLE
Unpack attempts as an unsigned 16-bit integer (rather than a signed int16)

### DIFF
--- a/lib/nsq/frames/message.rb
+++ b/lib/nsq/frames/message.rb
@@ -9,7 +9,7 @@ module Nsq
 
     def initialize(data, connection)
       super
-      @timestamp_in_nanoseconds, @attempts, @id, @body = @data.unpack('Q>s>a16a*')
+      @timestamp_in_nanoseconds, @attempts, @id, @body = @data.unpack('Q>S>a16a*')
       @body.force_encoding('UTF-8')
     end
 


### PR DESCRIPTION
After implementing `max_attempts` I noticed some rather old messages that had negative attempt counts. After investigating I noticed that the nsqd message format defines `attempts` as an unsigned 16-bit integer. The current `unpack` implementation is unpacking it as a *signed* integer which means you end up with negative attempts in ruby-land.

NSQ message format:
https://github.com/nsqio/nsq/blob/cc29d7202e35b6d94d361fa9890077048a1d0763/nsqd/message.go#L68-L77

Ruby unpack reference: https://ruby-doc.org/core-2.4.0/String.html#method-i-unpack

example:

```
[6] pry(main)> msg.data.unpack("Q>S>a16a*")[1]
=> 41677
[7] pry(main)> msg.data.unpack("Q>s>a16a*")[1]
=> -23859
[8] pry(main)> msg.attempts
=> -23859
```