### PR TITLE
adding protections to handle timeouts and dead servers.

### DIFF
--- a/lib/nsq/connection.rb
+++ b/lib/nsq/connection.rb
@@ -33,6 +33,8 @@ module Nsq
       @max_in_flight = opts[:max_in_flight] || 1
       @tls_options = opts[:tls_options]
       @max_attempts = opts[:max_attempts]
+      @connected_through_lookupd = false
+      @last_heartbeat = nil
       if opts[:ssl_context]
         if @tls_options
           warn 'ssl_context and tls_options both set. Using tls_options. Ignoring ssl_context.'
@@ -55,6 +57,10 @@ module Nsq
         raise ArgumentError, 'msg_timeout cannot be less than 1000. it\'s in milliseconds.'
       end
 
+      if opts[:connected_through_lookupd]
+        @connected_through_lookupd = opts[:connected_through_lookupd]
+      end
+
       # for outgoing communication
       @write_queue = SizedQueue.new(10000)
 
@@ -70,11 +76,17 @@ module Nsq
       start_monitoring_connection
     end
 
-
     def connected?
-      @connected
+      if @connected
+        if !@last_heartbeat.nil? && @last_heartbeat > Time.now - 40
+          true
+        else
+          false
+        end
+      else
+        false
+      end
     end
-
 
     # close the connection and don't try to re-open it
     def close
@@ -156,7 +168,16 @@ module Nsq
 
     def write_to_socket(raw)
       debug ">>> #{raw.inspect}"
-      @socket.write(raw)
+      begin
+        @socket.write_nonblock(raw)
+      rescue Errno::EWOULDBLOCK
+        if connected?
+          sleep 0.01
+          retry
+        else
+          raise "timeout"
+        end
+      end
     end
 
 
@@ -179,9 +200,9 @@ module Nsq
       write_to_socket ["IDENTIFY\n", metadata.length, metadata].pack('a*l>a*')
 
       # Now wait for the response!
-      frame = receive_frame
+      frame = receive_frame(5)  # timeout after 5 seconds to avoid hung servers
       server = JSON.parse(frame.data)
-
+      @last_heartbeat = Time.now
       if @max_in_flight > server['max_rdy_count']
         raise "max_in_flight is set to #{@max_in_flight}, server only supports #{server['max_rdy_count']}"
       end
@@ -193,6 +214,7 @@ module Nsq
     def handle_response(frame)
       if frame.data == RESPONSE_HEARTBEAT
         debug 'Received heartbeat'
+        @last_heartbeat = Time.now
         nop
       elsif frame.data == RESPONSE_OK
         debug 'Received OK'
@@ -202,13 +224,33 @@ module Nsq
     end
 
 
-    def receive_frame
-      if buffer = @socket.read(8)
-        size, type = buffer.unpack('l>l>')
-        size -= 4 # we want the size of the data part and type already took up 4 bytes
-        data = @socket.read(size)
-        frame_class = frame_class_for_type(type)
-        return frame_class.new(data, self)
+    def receive_frame(max_receive_time = nil)
+      break_after = nil
+      break_after = Time.now + max_receive_time if max_receive_time
+      begin
+        if buffer = @socket.read_nonblock(8)
+          size, type = buffer.unpack('l>l>')
+          size -= 4 # we want the size of the data part and type already took up 4 bytes
+          begin
+            data = @socket.read_nonblock(size)
+            frame_class = frame_class_for_type(type)
+            return frame_class.new(data, self)
+          rescue Errno::EWOULDBLOCK
+            if break_after.nil? || break_after > Time.now
+              sleep 0.01
+              retry
+            else
+              raise "timeout"
+            end
+          end
+        end
+      rescue Errno::EWOULDBLOCK
+        if break_after.nil? || break_after > Time.now
+          sleep 0.01
+          retry
+        else
+          raise "timeout"
+        end
       end
     end
 
@@ -260,7 +302,7 @@ module Nsq
           raise 'No data from socket'
         end
       end
-    rescue Exception => ex
+    rescue StandardError => ex
       die(ex)
     end
 
@@ -286,7 +328,7 @@ module Nsq
         break if data == :stop_write_loop
         write_to_socket(data)
       end
-    rescue Exception => ex
+    rescue StandardError => ex
       # requeue PUB and MPUB commands
       if data =~ /^M?PUB/
         debug "Requeueing to write_queue: #{data.inspect}"
@@ -404,19 +446,18 @@ module Nsq
     # https://github.com/ooyala/retries/blob/master/lib/retries.rb
     def with_retries(&block)
       base_sleep_seconds = 0.5
-      max_sleep_seconds = 300 # 5 minutes
+      max_sleep_seconds = 30 # 30 seconds
 
       # Let's do this thing
       attempts = 0
-
+      max_attempts = @connected_through_lookupd ? 10 : 100
       begin
         attempts += 1
         return block.call(attempts)
 
       rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::EHOSTUNREACH,
              Errno::ENETDOWN, Errno::ENETUNREACH, Errno::ETIMEDOUT, Timeout::Error => ex
-
-        raise ex if attempts >= 100
+        raise ex if attempts >= max_attempts
 
         # The sleep time is an exponentially-increasing function of base_sleep_seconds.
         # But, it never exceeds max_sleep_seconds.

--- a/lib/nsq/consumer.rb
+++ b/lib/nsq/consumer.rb
@@ -15,7 +15,7 @@ module Nsq
       @topic = opts[:topic] || raise(ArgumentError, 'topic is required')
       @channel = opts[:channel] || raise(ArgumentError, 'channel is required')
       @max_in_flight = opts[:max_in_flight] || 1
-      @discovery_interval = opts[:discovery_interval] || 60
+      @discovery_interval = opts[:discovery_interval] || 15
       @msg_timeout = opts[:msg_timeout]
       @max_attempts = opts[:max_attempts]
       @ssl_context = opts[:ssl_context]

--- a/lib/nsq/discovery.rb
+++ b/lib/nsq/discovery.rb
@@ -65,8 +65,8 @@ module Nsq
     # If there's an error, return nil
     def get_nsqds(lookupd, topic = nil)
       uri_scheme = 'http://' unless lookupd.match(%r(https?://))
-      uri = URI.parse("#{uri_scheme}#{lookupd}")
-
+      uri = URI("#{uri_scheme}#{lookupd}")
+      
       uri.query = "ts=#{Time.now.to_i}"
       if topic
         uri.path = '/lookup'
@@ -76,20 +76,31 @@ module Nsq
       end
 
       begin
-        body = Net::HTTP.get(uri)
-        data = JSON.parse(body)
-        producers = data['producers'] || # v1.0.0-compat
-                      (data['data'] && data['data']['producers'])
+        
+        Net::HTTP.start(uri.host, uri.port, :use_ssl => uri.scheme == 'https') do |client|
+          client.open_timeout = 10
+          client.read_timeout = 10
+          response = client.get(uri.path + "?" + uri.query)
+          if response.code == "200"
+            body = response.body
+            data = JSON.parse(body)
+            producers = data['producers'] || # v1.0.0-compat
+                          (data['data'] && data['data']['producers'])
 
-        if producers
-          producers.map do |producer|
-            "#{producer['broadcast_address']}:#{producer['tcp_port']}"
+            if producers
+              producers.map do |producer|
+                "#{producer['broadcast_address']}:#{producer['tcp_port']}"
+              end
+            else
+              []
+            end
+          else
+            []
           end
-        else
-          []
         end
-      rescue Exception => e
+      rescue StandardError => e
         error "Error during discovery for #{lookupd}: #{e}"
+        puts e.message
         nil
       end
     end

--- a/lib/nsq/exceptions.rb
+++ b/lib/nsq/exceptions.rb
@@ -1,5 +1,5 @@
 module Nsq
   # Raised when nsqlookupd discovery fails
-  class DiscoveryException < Exception; end
+  class DiscoveryException < StandardError; end
 end
 


### PR DESCRIPTION
I have ran into many timeout prone scenarios and this resolves them

if a lookupd times out  then set reasonable break and move on.
if an nsqd or server times out due to being out of memory or shutting down then timeout quickly and move on.

this fixes case where nsqd would timeout and hang the discovery process so no new servers were identified.   even if that nsqd was unreachable or came back.