### PR TITLE
Support specifying multiple nsqd's when creating a consumer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ nsq-ruby is a simple NSQ client library written in Ruby.
 ```Ruby
 require 'nsq'
 producer = Nsq::Producer.new(
-  nsqd: '127.0.0.1:4150',
+  nsqd: '127.0.0.1:4150', # OR ['127.0.0.1:4150']
   topic: 'some-topic'
 )
 
@@ -77,7 +77,7 @@ For example, if you'd like to publish messages to a single nsqd.
 
 ```Ruby
 producer = Nsq::Producer.new(
-  nsqd: '6.7.8.9:4150',
+  nsqd: '6.7.8.9:4150', # or ['6.7.8.9:4150']
   topic: 'topic-of-great-esteem'
 )
 ```
@@ -418,4 +418,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ nsq-ruby is a simple NSQ client library written in Ruby.
 ```Ruby
 require 'nsq'
 producer = Nsq::Producer.new(
-  nsqd: '127.0.0.1:4150', # OR ['127.0.0.1:4150']
+  nsqd: '127.0.0.1:4150', # or ['127.0.0.1:4150']
   topic: 'some-topic'
 )
 

--- a/lib/nsq/consumer.rb
+++ b/lib/nsq/consumer.rb
@@ -36,10 +36,14 @@ module Nsq
           topic: @topic,
           interval: @discovery_interval
         )
+
+      elsif opts[:nsqd]
+        nsqds = [opts[:nsqd]].flatten
+        max_per_conn = max_in_flight_per_connection(nsqds.size)
+        nsqds.each{|d| add_connection(d, max_in_flight: max_per_conn)}
+
       else
-        # normally, we find nsqd instances to connect to via nsqlookupd(s)
-        # in this case let's connect to an nsqd instance directly
-        add_connection(opts[:nsqd] || '127.0.0.1:4150', max_in_flight: @max_in_flight)
+        add_connection('127.0.0.1:4150', max_in_flight: @max_in_flight)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -66,7 +66,7 @@ end
 def new_producer(nsqd, opts = {})
   Nsq::Producer.new({
     topic: TOPIC,
-    nsqd: "#{nsqd.host}:#{nsqd.tcp_port}",
+    nsqd: ["#{nsqd.host}:#{nsqd.tcp_port}"],
     discovery_interval: 1
   }.merge(opts))
 end


### PR DESCRIPTION
This is needed to support more than one nsqd directly in the consumer without using `lookupds`. Without TLS support, `nsqlookupd` becomes difficult to use in a distributed infrastructure. 

This is how the producer works. I split the max in flight across connections which is how the consumer currently works when using discovery. 